### PR TITLE
CJS to ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "A development rig for Intro to Coding for Journalists, a class in the School of Journalism, Moody College of Communication, University of Texas at Austin.",
   "main": "index.html",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -35,7 +36,7 @@
     "gulp-eslint": "^6.0.0",
     "gulp-htmlmin": "^5.0.1",
     "gulp-if": "^3.0.0",
-    "gulp-imagemin": "^7.1.0",
+    "gulp-imagemin": "^8.0.0",
     "gulp-load-tasks": "^0.8.4",
     "gulp-newer": "^1.4.0",
     "gulp-nunjucks-render": "^2.2.3",
@@ -44,7 +45,7 @@
     "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-uglify": "^3.0.2",
-    "imagemin-mozjpeg": "^9.0.0",
+    "imagemin-mozjpeg": "^10.0.0",
     "imagemin-pngquant": "^6.0.1",
     "is-valid-glob": "^1.0.0",
     "journalize": "^2.5.1",

--- a/tasks/bake.js
+++ b/tasks/bake.js
@@ -1,20 +1,20 @@
-const gulp = require("gulp");
-const nunjucksRender = require("gulp-nunjucks-render");
-const config = require("../project.config.json");
+import gulp from 'gulp';
+import nunjucksRender from 'gulp-nunjucks-render';
+import config from '../project.config.json';
 
-const gulpData = require("gulp-data");
-const rename = require("gulp-rename");
-const browserSync = require("browser-sync").create();
-const isValidGlob = require("is-valid-glob");
+import gulpData from 'gulp-data';
+import rename from 'gulp-rename';
+import browserSync from 'browser-sync';
+import isValidGlob from 'is-valid-glob';
 
-//modularize manageEnv
-const journalize = require("journalize");
-const fs = require("fs");
+// modularize manageEnv
+import * as journalize from 'journalize';
+import fs from 'fs';
 
-module.exports = (resolve) => {
-  const dataDir = "src/data/";
+export function bake(resolve) {
+  const dataDir = 'src/data/';
 
-  //modularize manageEnv from nunjucks.js
+  // modularize manageEnv from nunjucks.js
   const manageEnv = function (env) {
     // loop over config vars to add to nunjucks global env
     // which can be added to project.config.json
@@ -24,25 +24,25 @@ module.exports = (resolve) => {
       }
     }
 
-    let data_dir = "src/data/";
+    let data_dir = 'src/data/';
 
     // loop over the directory of files
     fs.readdir(data_dir, function (err, files) {
       // handle errors
       if (err) {
-        console.error("Could not list the directory.", err);
+        console.error('Could not list the directory.', err);
         process.exit(1);
       }
 
       // for each file
       files.forEach(function (file, index) {
         // if it's a .json file
-        if (file.endsWith("json")) {
+        if (file.endsWith('json')) {
           // make the key the file name
-          let key = file.split(".json")[0];
+          let key = file.split('.json')[0];
 
           // and the value the file contents
-          let value = require("../" + data_dir + key);
+          let value = require('../' + data_dir + key);
 
           // and add to our global environment
           env.addGlobal(key, value);
@@ -53,7 +53,7 @@ module.exports = (resolve) => {
     // set up journalize
     for (let key in journalize) {
       let func = journalize[key];
-      if (typeof func === "function") {
+      if (typeof func === 'function') {
         env.addFilter(key, func);
       }
     }
@@ -80,7 +80,7 @@ module.exports = (resolve) => {
     }
 
     let data = require(`../${dataDir}${bake.data}.json`);
-    if (typeof data === "object") {
+    if (typeof data === 'object') {
       data = data[bake.array];
     }
     if (!data) {
@@ -107,14 +107,14 @@ module.exports = (resolve) => {
         .pipe(gulpData(d))
         .pipe(
           nunjucksRender({
-            path: "src/njk",
+            path: 'src/njk',
             manageEnv: manageEnv,
           })
         )
         .pipe(
           rename({
             basename: d[bake.slug],
-            extname: ".html",
+            extname: '.html',
           })
         )
         .pipe(gulp.dest(`docs/${bake.path}`))

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -1,7 +1,6 @@
-const gulp = require("gulp");
-const del = require("del");
+import del from 'del';
 
-module.exports = (resolve, reject) => {
-  del(["docs/*"], { dot: true });
+export function clean(resolve, reject) {
+  del(['docs/*'], { dot: true });
   resolve();
 };

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,6 +1,6 @@
-const gulp = require('gulp');
+import gulp from 'gulp';
 
-module.exports = () => {
+export function copy() {
   return gulp.src([
     'node_modules/jquery/dist/jquery.js',
     'node_modules/@popperjs/core/dist/umd/popper.js',

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -1,10 +1,10 @@
-const gulp = require('gulp');
-const cache = require('gulp-cache');
-const imagemin = require('gulp-imagemin');
-const imageminMozjpeg = require('imagemin-mozjpeg'); 
-const imageminPngquant = require('imagemin-pngquant');
+import gulp from 'gulp';
+import cache from 'gulp-cache';
+import imagemin from 'gulp-imagemin';
+import imageminMozjpeg from 'imagemin-mozjpeg'; 
+import imageminPngquant from 'imagemin-pngquant';
 
-module.exports = () => {
+export function images() {
   return gulp.src('./src/img/**/*')
     .pipe(cache(imagemin([
       // lossy jpg compression

--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -1,9 +1,9 @@
-const gulp = require('gulp');
-const gulpIf = require('gulp-if');
-const eslint = require('gulp-eslint');
-const browserSync = require('browser-sync');
+import gulp from 'gulp';
+import gulpIf from 'gulp-if';
+import eslint from 'gulp-eslint';
+import browserSync from 'browser-sync';
  
-module.exports = () => {
+export function lint() {
   return gulp.src(['src/js/**/*.js','!node_modules/**'])
     .pipe(eslint())
     .pipe(eslint.format())

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -1,12 +1,12 @@
-const gulp = require("gulp");
-const nunjucksRender = require("gulp-nunjucks-render");
-const journalize = require("journalize");
-const browserSync = require("browser-sync").create();
-const config = require("../project.config.json");
-const log = require("fancy-log");
-const fs = require("fs");
+import gulp from 'gulp';
+import nunjucksRender from 'gulp-nunjucks-render';
+import * as journalize from 'journalize';
+import browserSync from 'browser-sync';
+import config from '../project.config.json';
+import log from 'fancy-log';
+import fs from 'fs';
 
-module.exports = (resolve, reject) => {
+export function nunjucks(resolve, reject) {
   // nunjucks environment setup
   const manageEnv = function (env) {
     // loop over config vars to add to nunjucks global env
@@ -17,25 +17,25 @@ module.exports = (resolve, reject) => {
       }
     }
 
-    let data_dir = "src/data/";
+    let data_dir = 'src/data/';
 
     // loop over the directory of files
     fs.readdir(data_dir, function (err, files) {
       // handle errors
       if (err) {
-        console.error("Could not list the directory.", err);
+        console.error('Could not list the directory.', err);
         process.exit(1);
       }
 
       // for each file
       files.forEach(function (file, index) {
         // if it's a .json file
-        if (file.endsWith("json")) {
+        if (file.endsWith('json')) {
           // make the key the file name
-          let key = file.split(".json")[0];
+          let key = file.split('.json')[0];
 
           // and the value the file contents
-          let value = require("../" + data_dir + key);
+          let value = require('../' + data_dir + key);
 
           // and add to our global environment
           env.addGlobal(key, value);
@@ -46,7 +46,7 @@ module.exports = (resolve, reject) => {
     // set up journalize
     for (let key in journalize) {
       let func = journalize[key];
-      if (typeof func === "function") {
+      if (typeof func === 'function') {
         env.addFilter(key, func);
       }
     }
@@ -54,20 +54,20 @@ module.exports = (resolve, reject) => {
 
   gulp
     .src([
-      "src/njk/*.html",
-      "src/njk/*.njk",
-      "src/njk/**/*.njk",
-      "!src/njk/_*/",
-      "!src/njk/_*/**/*"
+      'src/njk/*.html',
+      'src/njk/*.njk',
+      'src/njk/**/*.njk',
+      '!src/njk/_*/',
+      '!src/njk/_*/**/*'
     ])
     .pipe(
       nunjucksRender({
-        path: "src/njk",
+        path: 'src/njk',
         manageEnv: manageEnv,
       })
     )
-    .on("error", log.error)
-    .pipe(gulp.dest("docs"))
+    .on('error', log.error)
+    .pipe(gulp.dest('docs'))
     .pipe(browserSync.stream());
   resolve();
 };

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -1,11 +1,11 @@
-const gulp = require('gulp');
-const newer = require('gulp-newer');
-const sourcemaps = require('gulp-sourcemaps');
-const babel = require('gulp-babel');
-const concat = require('gulp-concat');
-const uglify = require('gulp-uglify');
+import gulp from 'gulp';
+import newer from 'gulp-newer';
+import sourcemaps from 'gulp-sourcemaps';
+import babel from 'gulp-babel';
+import concat from 'gulp-concat';
+import uglify from 'gulp-uglify';
  
-module.exports = () => {
+export function scripts() {
   return gulp.src([
     './src/js/main.js'
   ])

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -1,14 +1,16 @@
-const gulp = require('gulp');
-const postcss = require('gulp-postcss');
-const newer = require('gulp-newer');
-const sourcemaps = require('gulp-sourcemaps');
-var sass = require('gulp-sass')(require('sass'));
-const autoprefixer = require('gulp-autoprefixer');
-const cssnano = require('cssnano');
-const log = require('fancy-log');
-const browserSync = require('browser-sync').create();
+import gulp from 'gulp';
+import postcss from 'gulp-postcss';
+import newer from 'gulp-newer';
+import sourcemaps from 'gulp-sourcemaps';
+import dartSass from 'sass';
+import gulpSass from 'gulp-sass';
+var sass = gulpSass(dartSass);
+import autoprefixer from 'gulp-autoprefixer';
+import cssnano from 'cssnano';
+import log from 'fancy-log';
+import browserSync from 'browser-sync';
 
-module.exports = () => {
+export function styles() {
   const AUTOPREFIXER_BROWSERS = [
     'ie >= 10',
     'ie_mob >= 10',
@@ -23,7 +25,7 @@ module.exports = () => {
 
   var plugins = [
     cssnano()
-    ];
+  ];
   
   return gulp.src([
     'src/scss/*.scss'
@@ -37,4 +39,4 @@ module.exports = () => {
     .pipe(sourcemaps.write())
     .pipe(gulp.dest('./docs/css'))
     .pipe(browserSync.stream());
-  };
+};


### PR DESCRIPTION
Addresses #79.

Where I left off:
1) As it stands, need to run `gulp --experimental-json-modules dev` because ES6 support for JSON files is still experimental (and we import `project.config.json`)
2) `nunjucks` and `bake` don't work yet because `require` imports some files throughout the script, and you can't use `import` statements anywhere but the top of the file