### PR TITLE
Remove duplicate `clean` command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,6 @@ import styles from './tasks/styles.js';
 // default tasks
 gulp.task('default', (done) => {
   runSequence(
-    'clean',
     [clean, styles, copy, gulp.parallel(lint, scripts, images), nunjucks, bake],
     format,
     done


### PR DESCRIPTION
## Describe your changes
Removed duplicate instance of `clean` command.

## Checklist before requesting a review
- [x] All features within the repository still work on my local dev environment.

```bash
icj-project-rig % gulp dev
`import sass from 'sass'` is deprecated.
Please use `import * as sass from 'sass'` instead.
[00:38:39] Using gulpfile ~/Documents/GitHub/icj-project-rig/gulpfile.js
[00:38:39] Starting 'dev'...
[00:38:39] Starting 'default'...
[00:38:39] Starting 'clean'...
[00:38:39] Starting 'styles'...
[00:38:39] Starting 'copy'...
[00:38:39] Starting 'nunjucks'...
[00:38:39] Starting 'bake'...
[00:38:39] Finished 'clean' after 3.97 ms
[00:38:39] Starting 'lint'...
[00:38:39] Starting 'scripts'...
[00:38:39] Starting 'images'...
[00:38:39] Finished 'nunjucks' after 126 ms
[00:38:39] Finished 'bake' after 128 ms
[00:38:39] Finished 'lint' after 425 ms
[00:38:42] Finished 'styles' after 3.02 s
[00:38:42] gulp-imagemin: Minified 0 images
[00:38:42] Finished 'scripts' after 2.89 s
[00:38:42] Finished 'copy' after 3.02 s
[00:38:42] Finished 'images' after 2.89 s
[00:38:42] Starting 'format'...
[00:38:42] File 'docs/books/the-clown.html' was not formatted with Prettier
[00:38:42] File 'docs/books/the-hearing-trumpet.html' was not formatted with Prettier
[00:38:42] File 'docs/books/the-shipping-news.html' was not formatted with Prettier
[00:38:42] File 'docs/index.html' was not formatted with Prettier
[00:38:42] Finished 'format' after 103 ms
[00:38:42] Finished 'default' after 3.12 s
[00:38:42] Starting 'serve'...
[Browsersync] Access URLs:
 --------------------------------------
       Local: http://localhost:3001
    External: http://192.168.0.116:3001
 --------------------------------------
          UI: http://localhost:3002
 UI External: http://localhost:3002
 --------------------------------------
[Browsersync] Serving files from: docs
```
