### PR TITLE
Pull Google JSON credentials from env variable. Issue #112

### DIFF
--- a/tasks/fetch.js
+++ b/tasks/fetch.js
@@ -11,6 +11,7 @@ const config = fs.readJsonSync('./project.config.json');
 
 async function getData() {
   const auth = await google.auth.getClient({
+    credentials: JSON.parse(process.env.SERVICE_ACCOUNT_CREDENTIALS),
     scopes: [
       'https://www.googleapis.com/auth/documents.readonly',
       'https://www.googleapis.com/auth/spreadsheets.readonly'

--- a/tasks/fetch.js
+++ b/tasks/fetch.js
@@ -11,6 +11,7 @@ const config = fs.readJsonSync('./project.config.json');
 
 async function getData() {
   const auth = await google.auth.getClient({
+    // eslint-disable-next-line no-process-env
     credentials: JSON.parse(process.env.SERVICE_ACCOUNT_CREDENTIALS),
     scopes: [
       'https://www.googleapis.com/auth/documents.readonly',


### PR DESCRIPTION
## Describe your changes

Parses the credentials from an environment variable. Needs to be stored as a string, which is then parsed into JSON.

