### PR TITLE
Load service credentials out of service_account_key.json if available

### DIFF
--- a/tasks/fetch.js
+++ b/tasks/fetch.js
@@ -9,7 +9,7 @@ import { sheetToData } from '@newswire/sheet-to-data';
 // eslint-disable-next-line no-sync
 const config = fs.readJsonSync('./project.config.json');
 
-var serviceAccountCredentials = null;
+let serviceAccountCredentials = null;
 // eslint-disable-next-line no-sync
 if (fs.existsSync('./service_account_key.json')) {
   // eslint-disable-next-line no-sync

--- a/tasks/fetch.js
+++ b/tasks/fetch.js
@@ -9,10 +9,22 @@ import { sheetToData } from '@newswire/sheet-to-data';
 // eslint-disable-next-line no-sync
 const config = fs.readJsonSync('./project.config.json');
 
+var serviceAccountCredentials = null;
+// eslint-disable-next-line no-sync
+if (fs.existsSync('./service_account_key.json')) {
+  // eslint-disable-next-line no-sync
+  serviceAccountCredentials = fs.readFileSync('./service_account_key.json');
+}
+
+// eslint-disable-next-line no-process-env
+if (process.env.SERVICE_ACCOUNT_CREDENTIALS) {
+  // eslint-disable-next-line no-process-env
+  serviceAccountCredentials = process.env.SERVICE_ACCOUNT_CREDENTIALS;
+}
+
 async function getData() {
   const auth = await google.auth.getClient({
-    // eslint-disable-next-line no-process-env
-    credentials: JSON.parse(process.env.SERVICE_ACCOUNT_CREDENTIALS),
+    credentials: JSON.parse(serviceAccountCredentials),
     scopes: [
       'https://www.googleapis.com/auth/documents.readonly',
       'https://www.googleapis.com/auth/spreadsheets.readonly'


### PR DESCRIPTION
## Describe your changes

The rig will now check `service_account_key.json` for the Google Account credentials before checking process.env - this allows the user to override the google account credentials if needed.

## Checklist before requesting a review
- [X] All features within the repository still work on my local dev environment.

```bash
LOCAL GULP OUTPUT
gulp fetch
`import sass from 'sass'` is deprecated.
Please use `import * as sass from 'sass'` instead.
[09:38:56] Using gulpfile ~/Projects/ut/icj-project-rig/gulpfile.js
[09:38:56] Starting 'fetch'...
[09:38:56] Finished 'fetch' after 1.27 ms
Downloaded `library` (1RgMhjtkXlbbf9uzSzy_xPRKwxcVZIZqVytgM_JoU4E4)
Downloaded `bookstores` (1gDwO-32cgpBDn_0niV0iu6TqQTaRDr4nmSqnT53magY)
```
- [X] All features within the repository still work on Codespaces.

```bash
CODESPACES GULP OUTPUT
```
